### PR TITLE
Update prueba2.arit

### DIFF
--- a/Arit-1s2020/prueba2.arit
+++ b/Arit-1s2020/prueba2.arit
@@ -1125,10 +1125,14 @@ main();
 
 
 print("alumnos random que va ganar compi")
-print("A"+seccionA[48])
-print("B-"+seccionBMenos[13])
-print("B+"+seccionBMas[29])
-print("C"+seccionC[3])
+print("seccion A");
+print(seccionA[48])
+print("seccion B-");
+print(seccionBMenos[13])
+print("seccion B+");
+print(seccionBMas[29])
+print("seccion C");
+print(seccionC[3])
 
 
 print("J# IS COMING <3")
@@ -1164,3 +1168,4 @@ print("##############-SALIDA ESPERADA-##########################################
 >>
 *#
 #201314164
+#201701048


### PR DESCRIPTION
Modifiqué la impresión de los 'alumnos random que van a ganar compi' ya que, como estaban antes, hacia una operación aritmética entre STRING y LIST, y según el enunciado no hay operaciones aritméticas con las listas, únicamente con matrices y vectores.  Lo solucioné agregando una etiqueta para identificar la sección del alumno antes de la impresión de sus datos. Soy Ronald Gabriel Romero González, 201701048, de la sección B+.  Se tendrá una salida semejante a la siguiente: 
![image](https://user-images.githubusercontent.com/46333815/77871478-79aaec80-7201-11ea-9ae5-d2c2409bb621.png)

