### PR TITLE
Actualización getPivot

### DIFF
--- a/MatrioshTS-2s2020/Ordenamiento.ts
+++ b/MatrioshTS-2s2020/Ordenamiento.ts
@@ -1,5 +1,5 @@
-function getPivot(value : number) : number{
-    return value % 2 == 0 ? value : value - 0.5;
+function getPivot(value: number): number {
+    return (value % 2 == 0 || value % 2 == 1) ? value : value - 0.5;
 }
 
 function swap(i : number, j: number, array : number[]) : void{


### PR DESCRIPTION
Para evitar resultado erróneo cuando se evalue el módulo de un número impar, que afecta al ordenamiento del quicksort.